### PR TITLE
Added issue, feature, and documentation templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,25 @@
+name: 🐛 Bug
+description: Report an issue to help improve the project.
+labels: ["🛠 goal: fix", "🚦 status: awaiting triage"]
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: A brief description of the question or issue, also include what you tried and what didn't work
+    validations:
+      required: true
+  - type: textarea
+    id: screenshots
+    attributes:
+      label: Screenshots
+      description: Please add screenshots if applicable
+    validations:
+      required: false
+  - type: textarea
+    id: extrainfo
+    attributes:
+      label: Additional information
+      description: Is there anything else we should know about this bug?
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/docs.yml
+++ b/.github/ISSUE_TEMPLATE/docs.yml
@@ -1,0 +1,26 @@
+name: 📄 Documentation issue
+description: Found an issue in the documentation? You can use this one!
+title: "[DOCS] <description>"
+labels: ["📄 aspect: text", "🚦 status: awaiting triage"]
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: A brief description of the question or issue, also include what you tried and what didn't work
+    validations:
+      required: true
+  - type: textarea
+    id: screenshots
+    attributes:
+      label: Screenshots
+      description: Please add screenshots if applicable
+    validations:
+      required: false
+  - type: textarea
+    id: extrainfo
+    attributes:
+      label: Additional information
+      description: Is there anything else we should know about this issue?
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,26 @@
+name: General Feature Request 💡
+description: Have a new idea/feature for LinkFree? Please suggest!
+title: "[FEATURE] <description>"
+labels: ["⭐ goal: addition", "🚦 status: awaiting triage"]
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: A brief description of the enhancement you propose, also include what you tried and what worked.
+    validations:
+      required: true
+  - type: textarea
+    id: screenshots
+    attributes:
+      label: Screenshots
+      description: Please add screenshots if applicable
+    validations:
+      required: false
+  - type: textarea
+    id: extrainfo
+    attributes:
+      label: Additional information
+      description: Is there anything else we should know about this idea?
+    validations:
+      required: false


### PR DESCRIPTION
`Explanation:`
I have created and added three new templates to the repository, aiming to improve the GitHub issue creation process, feature requests, and documentation contributions. These templates introduce a standardized format for creating issues, requesting features, and documenting project details. By implementing these templates, contributors and maintainers will be able to collaborate more effectively.


[here is demo of templates. : ](https://github.com/Nishitbaria/Shorty/tree/66090ccce1ba7faa6d2cc13ad82c6c3e5d6d5ddf/.github/ISSUE_TEMPLATE)
