### PR TITLE
💡 [FEAT]: ACCESSIBLE SOCIAL ANCHORS & SOME MINOR CHANGES

### DIFF
--- a/index.php
+++ b/index.php
@@ -338,9 +338,36 @@
             </a>
 
             <div class="social-links d-flex mt-4" style="justify-content: center;padding-bottom: 3%;">
-              <a target="_blank"  href="https://github.com/apoorvaron" class="github"><i class="bi bi-github"></i></a>
-              <a target="_blank"  href="https://www.linkedin.com/in/apoorv-aron-742882212/" class="linkedin"><i class="bi bi-linkedin"></i></a>
-              <a target="_blank"  href="https://twitter.com/AronApoorv" class="twitter"><i class="bi bi-twitter"></i></a>
+              <a 
+                 target="_blank" 
+                 rel=”noopener noreferrer” 
+                 aria-label="Follow Apoorv on Github" 
+                 title="Link to Github profile (External Link)" 
+                 href="https://github.com/apoorvaron" 
+                 class="github"
+                >
+                      <i class="bi bi-github"></i>
+              </a>
+              <a 
+                 target="_blank" 
+                 rel=”noopener noreferrer” 
+                 aria-label="Follow Apoorv on LinkedIn" 
+                 title="Link to Linkedin profile (External Link)" 
+                 href="https://www.linkedin.com/in/apoorv-aron-742882212/" 
+                 class="linkedin"
+                >
+                      <i class="bi bi-linkedin"></i>
+              </a>
+              <a 
+                 target="_blank" 
+                 rel=”noopener noreferrer” 
+                 aria-label="Follow Apoorv on Twitter" 
+                 title="Link to Twitter profile (External Link)" 
+                 href="https://twitter.com/AronApoorv" 
+                 class="twitter"
+                >
+                      <i class="bi bi-twitter"></i>
+              </a>
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Related Issue
- Fixes/Closes: #80 

## Changes proposed
- Added `aria-label` attribute for social anchors like github & twitter
- The `aria-label` attribute is important for screen readers because it provides a text label for an object, such as `a` with social icons. When a screen reader encounters the object, the `aria-label` text is read so that the user will know what it is. 
- This is important for people who are blind or have low vision, as they rely on screen readers to access the web.
- Added `title` attribute, because the title attribute is intended to provide additional information to screen reader users.
- And along with that i added `rel` for the anchors which are lacking them to ensure best practices for crawlers
- Because adding the `rel="noopener noreferrer"` attribute can help to protect this website from security vulnerabilities and improve performance. It is a good practice to use this attribute on all external links.
- Overall this PR is intended to make necessary changes to meet best practices for crawlers along with improving accessibility for social anchors

## Checklist:

- [x] My code adheres to the established style guidelines of this project.
- [x] I have conducted a self-review of my code.
- [x] I have included comments in areas that may be difficult to understand.
- [x] I have made corresponding updates to the project documentation.
- [x] My changes have not introduced any new warnings.


## Screenshots
- We can't take screenshots of accessibility changes rather than code changes, Accessibility changes are often invisible to the user because it's intended to guide disabled people
