### PR TITLE
modified opactiy of navbar to avoid main content shown in navbar

### DIFF
--- a/index.php
+++ b/index.php
@@ -133,7 +133,7 @@
 
   <body>
     <!-- ======= Header ======= -->
-    <header id="header" class="header d-flex align-items-center fixed-top">
+    <header id="header" class="header d-flex align-items-center fixed-top" style="opacity:1;background:rgb(14,29,52);">
       <div
         class="container-fluid container-xl d-flex align-items-center justify-content-between"
       >


### PR DESCRIPTION
The main content of the website is showing in navbar

Closes: #53 



I modified index.php and added following the style attribute 
--opacity to 1
--background(14,29,52)



## Screenshots
 Original     
<img width="889" alt="Screenshot 2023-05-28 041428" src="https://github.com/apoorvaron/Shorty/assets/111435565/193e6324-7046-45b0-87a1-a1b33c27e4a0"> 
Updated 
<img width="960" alt="image" src="https://github.com/apoorvaron/Shorty/assets/111435565/02caf4f1-668e-4ac5-a9b1-c37ec21f7207">


