### PR TITLE
Enter Key Pressed Refresh Error Updated

### DIFF
--- a/index.php
+++ b/index.php
@@ -152,8 +152,9 @@ if ($rows == 0) {
 
           <form class="form-search d-flex align-items-stretch mb-3" data-aos="fade-up" data-aos-delay="200"
             method="POST">
-            <input type="text" class="form-control" style="font-size: 0.9rem;" placeholder="Your Link"
-              id="originalLink" />
+            <input type="text" class="form-control" style="font-size: 0.9rem;" placeholder="Your Link" id="originalLink"
+              onkeydown="if(event.keyCode === 13) { event.preventDefault(); generateShorty(); }">
+
             <button type="button" class="btn btn-primary" onclick="generateShorty()">Shorten</button>
           </form>
           <div id="generateShorty"></div>


### PR DESCRIPTION
## Related Issue

Closes: #101 


## Description of Changes
This pull request addresses an issue where pressing the "Enter" key on the page caused a page reload instead of shortening the given URL. To fix this issue, the following changes were made to the `index.php` file:

- Modified the `originalLink` input field by adding an `onkeydown` event handler.
- Updated the `originalLink` input field from:

  ```html
  <input type="text" class="form-control" style="font-size: 0.9rem;" placeholder="Your Link" id="originalLink">
  ```

  to:

  ```html
  <input type="text" class="form-control" style="font-size: 0.9rem;" placeholder="Your Link" id="originalLink"
          onkeydown="if(event.keyCode === 13) { event.preventDefault(); generateShorty(); }">
  ```
## Checklist:

<!--
Mark the checkboxes to indicate completion. Example: 
- [x] My code follows the style guidelines of this project.
-->

- [x] My code adheres to the established style guidelines of this project.
- [x] I have conducted a self-review of my code.
- [x] I have included comments in areas that may be difficult to understand.
- [ ] I have made corresponding updates to the project documentation.
- [x] My changes have not introduced any new warnings.


## Screenshots


### Desktop
https://github.com/apoorvaron/Shorty/assets/85815172/208ec6d0-debe-45ec-8250-009a80ce79ed

### Android


https://github.com/apoorvaron/Shorty/assets/85815172/2cadb731-1407-4196-8867-a525ec72e6ae


