### PR TITLE
🚀 Fixing Fragment Link Saving - Improved Handling 🔧🔗

### DIFF
--- a/includes/footer.php
+++ b/includes/footer.php
@@ -92,9 +92,10 @@
         function generateShorty() {
 
             let originalLink = document.querySelector('#originalLink').value;
+            let originalLinkWithoutFragment = originalLink.split('#')[0];
 
             // Check original link was shortened previously 
-            let urllink = "./admin/dBconn/api.php?q=getAlreadyShortened&originalLink=" + originalLink;
+            let urllink = "./admin/dBconn/api.php?q=getAlreadyShortened&originalLink=" + originalLinkWithoutFragment;
             let linkPage = document.getElementById("linkPage");
             $(document).ready(function () {
                 $.ajax({
@@ -116,7 +117,7 @@
                         let regexp = /^(?:(?:https?|ftp):\/\/)?(?:(?!(?:10|127)(?:\.\d{1,3}){3})(?!(?:169\.254|192\.168)(?:\.\d{1,3}){2})(?!172\.(?:1[6-9]|2\d|3[0-1])(?:\.\d{1,3}){2})(?:[1-9]\d?|1\d\d|2[01]\d|22[0-3])(?:\.(?:1?\d{1,2}|2[0-4]\d|25[0-5])){2}(?:\.(?:[1-9]\d?|1\d\d|2[0-4]\d|25[0-4]))|(?:(?:[a-z\u00a1-\uffff0-9]-*)*[a-z\u00a1-\uffff0-9]+)(?:\.(?:[a-z\u00a1-\uffff0-9]-*)*[a-z\u00a1-\uffff0-9]+)*(?:\.(?:[a-z\u00a1-\uffff]{2,})))(?::\d{2,5})?(?:\/\S*)?$/;
 
 
-                        if (regexp.test(originalLink)) {
+                        if (regexp.test(originalLinkWithoutFragment)) {
                             let generateShorty = document.querySelector('#generateShorty');
                             let full_shortlink = "<?php echo $env_domain ?>";
                             // full_shortlink.slice(0, -2);
@@ -135,7 +136,7 @@
                             let originalLink = document.querySelector('#originalLink').value;
 
                             var formData = new FormData();
-                            formData.append('originalLink', originalLink);
+                            formData.append('originalLink', originalLinkWithoutFragment);
                             // formData.append('shortenLink', avail);
 
 
@@ -178,53 +179,6 @@
                 });
             });
         }
-
-
-        // function generateCustomShorty() {
-        //     let originalLink = document.querySelector('#originalLink').value;
-        //     let shortenLink = document.querySelector('#shortenLink').value;
-        //     console.log(originalLink)
-        //     console.log(shortenLink)
-        //     // Generate a new shortened link
-        //     let avail = shortenLink;
-
-        //     let regexp = /^(?:(?:https?|ftp):\/\/)?(?:(?!(?:10|127)(?:\.\d{1,3}){3})(?!(?:169\.254|192\.168)(?:\.\d{1,3}){2})(?!172\.(?:1[6-9]|2\d|3[0-1])(?:\.\d{1,3}){2})(?:[1-9]\d?|1\d\d|2[01]\d|22[0-3])(?:\.(?:1?\d{1,2}|2[0-4]\d|25[0-5])){2}(?:\.(?:[1-9]\d?|1\d\d|2[0-4]\d|25[0-4]))|(?:(?:[a-z\u00a1-\uffff0-9]-*)*[a-z\u00a1-\uffff0-9]+)(?:\.(?:[a-z\u00a1-\uffff0-9]-*)*[a-z\u00a1-\uffff0-9]+)*(?:\.(?:[a-z\u00a1-\uffff]{2,})))(?::\d{2,5})?(?:\/\S*)?$/;
-        //     let ifValidLink = regexp.test(originalLink);
-        //     if (ifValidLink) {
-        //         console.log("Testing", ifValidLink);
-        //         let generateShorty = document.querySelector('#generateShorty');
-        //         let full_shortlink = "<?php echo $env_domain ?>";
-        //         generateShorty.innerHTML = `
-        //     <form class="form-search d-flex align-items-stretch mb-3" data-aos="fade-up" data-aos-delay="200">
-        //         <input type="text" id="shortInput" disabled style="font-size: 0.9rem;" disbaled class="form-control" placeholder="" value="<?php echo $env_domain ?>${avail}"/>
-        //         <input class="btn btn-primary" type="button" onclick="copy()" id="copyBtn" value="Copy">
-        //     </form>
-        // `;
-
-        //         let originalLink = document.querySelector('#originalLink').value;
-
-        //         var formData = new FormData();
-        //         formData.append('originalLink', originalLink);
-
-        //         let url = "./admin/dBconn/api.php/?q=shorty&shortenLink=" + avail;
-        //         $.ajax({
-        //             type: "POST",
-        //             url: "./admin/dBconn/api.php/?q=shorty&shortenLink=" + avail,
-        //             data: formData,
-        //             cache: false,
-        //             processData: false,
-        //             contentType: false,
-        //             success: function (data) {
-        //                 console.log("success");
-        //             },
-        //             error: function (xhr, status, error) {
-        //                 console.log("No");
-        //             },
-        //         });
-        //     } else {
-        //         swal("Enter Valid URL !!", "", "error");
-        //     }
-        // }
 
 
         function generateCustomShorty() {
@@ -299,7 +253,6 @@
                 },
             });
         }
-
 
     </script>
 </footer>


### PR DESCRIPTION
## Related Issue
Closes: #265

## Description of Changes

Resolved issue with fragment portion of links inadvertently saving, ensuring only the URL is stored in the database. Users can now access saved links without errors. 🌟🔒

Changes Made:
In the implementation, the following change has been made:

```php
let originalLinkWithoutFragment = originalLink.split('#')[0];
```

This code snippet removes all fragments from the URL/Link and updates the link in the database without the fragment, thus addressing the issue effectively.

## Checklist:



- [x] My code adheres to the established style guidelines of this project.
- [x] I have conducted a self-review of my code.
- [ ] I have included comments in areas that may be difficult to understand.
- [ ] I have made corresponding updates to the project documentation.
- [x] My changes have not introduced any new warnings.


## Screenshots


https://github.com/apoorvaron/Shorty/assets/85815172/0826fb65-02b1-4704-844f-367d5c8b80c8




