### PR TITLE
feat: make custom link form accessible ✨ 

### DIFF
--- a/assets/css/shorty.css
+++ b/assets/css/shorty.css
@@ -2328,3 +2328,14 @@ a:not(.get-a-quote, .social-links a):hover {
 ::-webkit-scrollbar-thumb:hover {
 	background: #0d6eff;
 }
+
+.sr-only-labels {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border-width: 0;
+}

--- a/guest.php
+++ b/guest.php
@@ -383,8 +383,8 @@ if ($rows == 0) {
               </h2>
               <hr style="color:gray;">
               <div class="inputIconContainer" id="linkIcon">
-              <i class="bi bi-link-45deg"></i>
 	      <label for="originalLink" class="sr-only-labels">Enter your original link: </label>
+              <i class="bi bi-link-45deg"></i>
               <input type="text" id="originalLink" class="form-control mb-3 mt-3" style="font-size: 0.9rem;" placeholder="Your Link"
                 id="originalLink" name="originalLink"
                 onkeydown="if(event.keyCode === 13) { event.preventDefault(); generateCustomShorty(); }" />

--- a/guest.php
+++ b/guest.php
@@ -393,7 +393,7 @@ if ($rows == 0) {
               <div class="inputIconContainer" style=" padding-left: 0px;">
               <i class="bi bi-browser-chrome"></i>
                 <span class="form-group mt-3 mb-4" id="formSpan">
-                  <label for="shortenLink" class="sr-only-labels">
+                  <label for="shortenLink">
                     <p style="margin: 0px !important;color:#555; font-weight: 900;">
                       <?php echo $env_domain ?>
                     </p>

--- a/guest.php
+++ b/guest.php
@@ -384,7 +384,8 @@ if ($rows == 0) {
               <hr style="color:gray;">
               <div class="inputIconContainer" id="linkIcon">
               <i class="bi bi-link-45deg"></i>
-              <input type="text" class="form-control mb-3 mt-3" style="font-size: 0.9rem;" placeholder="Your Link"
+	      <label for="originalLink" class="sr-only-labels">Enter your original link: </label>
+              <input type="text" id="originalLink" class="form-control mb-3 mt-3" style="font-size: 0.9rem;" placeholder="Your Link"
                 id="originalLink" name="originalLink"
                 onkeydown="if(event.keyCode === 13) { event.preventDefault(); generateCustomShorty(); }" />
               </div>
@@ -392,12 +393,12 @@ if ($rows == 0) {
               <div class="inputIconContainer" style=" padding-left: 0px;">
               <i class="bi bi-browser-chrome"></i>
                 <span class="form-group mt-3 mb-4" id="formSpan">
-                  <label>
+                  <label for="shortenLink" class="sr-only-labels">
                     <p style="margin: 0px !important;color:#555; font-weight: 900;">
                       <?php echo $env_domain ?>
                     </p>
                   </label>
-                  <span><input type="text" class="form-control mb-4 mt-3" placeholder="Custom Name"
+                  <span><input type="text" id="shortenLink" class="form-control mb-4 mt-3" placeholder="Custom Name"
                       style="border:0px;font-size: 0.9rem;margin: 0px !important;padding:0;" required
                       id="shortenLink" name="shortenLink"
                       onkeydown="if(event.keyCode === 13) { event.preventDefault(); generateCustomShorty(); }" /></span>
@@ -406,7 +407,7 @@ if ($rows == 0) {
               </div>
               <div class="d-flex justify-content-between" id="buttonresp">
                 <button type="button" class="btn btn-primary" id="generateRandom">Random Number</button>
-                <button type="button" class="btn btn-primary" name="" onclick="generateCustomShorty()"
+                <button type="button" role="button" aria-describedby="Click this button to shorten your link" class="btn btn-primary" name="" onclick="generateCustomShorty()"
                   class="btn-get-started">Shorten
                   Link</button>
 


### PR DESCRIPTION
## Related Issue

Closes: #278

## Description of Changes
- Made Custom link form accessible by adding proper labels with associating corresponding input fields using `for`, `id` & `name` attributes.
- Additionally we hide them using screen reader only styles, So normal could not able to see the label elements but accessibility devices can able to announce and read them to the disabled user.

## Checklist:

<!--
Mark the checkboxes to indicate completion. Example: 
- [x] My code follows the style guidelines of this project.
-->

- [x] My code adheres to the established style guidelines of this project.
- [x] I have conducted a self-review of my code.
- [x] I have included comments in areas that may be difficult to understand.
- [x] I have made corresponding updates to the project documentation.
- [x] My changes have not introduced any new warnings.


## Screenshots
- We can't capture accessibility changes through screenshots as opposed to code changes since accessibility modifications are often imperceptible to the user, as their purpose is to assist disabled individ